### PR TITLE
Don’t emit sourcemaps

### DIFF
--- a/.changeset/tall-pigs-write.md
+++ b/.changeset/tall-pigs-write.md
@@ -1,0 +1,5 @@
+---
+"expressive-code-color-chips": patch
+---
+
+Reduces package size by almost 50% by not shipping source maps

--- a/packages/expressive-code-color-chips/package.json
+++ b/packages/expressive-code-color-chips/package.json
@@ -28,7 +28,7 @@
 		"dist"
 	],
 	"scripts": {
-		"build": "tsup ./src/index.ts --format esm --dts --sourcemap --clean",
+		"build": "tsup ./src/index.ts --format esm --dts --clean",
 		"watch": "pnpm build --watch src"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The build for this package currently includes source maps which I don’t think are useful to anyone and account for almost 50% of the package size on npm.

This PR turns off sourcemap generation to make for a lighter install size.