### PR TITLE
Add `languages` option to enable color chips in other languages

### DIFF
--- a/.changeset/color-chip-languages-option.md
+++ b/.changeset/color-chip-languages-option.md
@@ -1,0 +1,5 @@
+---
+'expressive-code-color-chips': minor
+---
+
+Adds a `languages` option to `pluginColorChips()` to control which languages get color chips. The value you provide replaces the built-in CSS dialects, for example: `pluginColorChips({ languages: ['css', 'json'] })`.

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -5,9 +5,21 @@ description: Optional configuration for the Expressive Code Color Chips plugin, 
 
 After adding the Color Chips plugin to your Expressive Code config as shown in [the set-up guide](/expressive-code-color-chips/getting-started/), no further configuration is required.
 
-If you want to customize the appearance of the color chips, you can use style overrides.
+## Additional languages
+
+By default, the plugin annotates colors in `css`, `scss`, `sass`, `less`, and `stylus` code blocks. Use the `languages` option to control which languages get color chips, for example to enable them for another language that includes color values.
+
+```js
+{
+	plugins: [pluginColorChips({ languages: ['css', 'json'] })],
+},
+```
+
+The value you provide replaces the defaults, so include any of the built-in CSS dialects you still want to annotate.
 
 ## Styling
+
+If you want to customize the appearance of the color chips, you can use style overrides.
 
 You can provide custom styles in your Expressive Code config using the `styleOverrides.colorChips` object.
 

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -5,6 +5,8 @@ description: Optional configuration for the Expressive Code Color Chips plugin, 
 
 After adding the Color Chips plugin to your Expressive Code config as shown in [the set-up guide](/expressive-code-color-chips/getting-started/), no further configuration is required.
 
+If you want to customize the behaviour of the plugin, you can pass a configuration object to `pluginColorChips()`.
+
 ## Additional languages
 
 By default, the plugin annotates colors in `css`, `scss`, `sass`, `less`, and `stylus` code blocks. Use the `languages` option to control which languages get color chips, for example to enable them for another language that includes color values.
@@ -18,8 +20,6 @@ By default, the plugin annotates colors in `css`, `scss`, `sass`, `less`, and `s
 The value you provide replaces the defaults, so include any of the built-in CSS dialects you still want to annotate.
 
 ## Styling
-
-If you want to customize the appearance of the color chips, you can use style overrides.
 
 You can provide custom styles in your Expressive Code config using the `styleOverrides.colorChips` object.
 

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -5,7 +5,7 @@ description: Optional configuration for the Expressive Code Color Chips plugin, 
 
 After adding the Color Chips plugin to your Expressive Code config as shown in [the set-up guide](/expressive-code-color-chips/getting-started/), no further configuration is required.
 
-If you want to customize the behaviour of the plugin, you can pass a configuration object to `pluginColorChips()`.
+If you want to customize the behaviour of the plugin, you can pass options to `pluginColorChips()` and use Expressive Code’s style overrides.
 
 ## Additional languages
 

--- a/packages/expressive-code-color-chips/src/index.ts
+++ b/packages/expressive-code-color-chips/src/index.ts
@@ -11,8 +11,8 @@ import { colors } from './colorRegEx';
 
 const chipClass = 'ec-css-color-chip';
 const localColorVariable = '--ec-css-color-chip';
-/** Language tags where CSS color annotations should apply. */
-const cssDialects = new Set(['css', 'scss', 'sass', 'less', 'stylus']);
+/** Language tags where CSS color annotations apply by default. */
+const cssDialects = ['css', 'scss', 'sass', 'less', 'stylus'];
 
 /** Adds an annotation to a CSS color, which will display that color as a chip next to it. */
 class CssColorAnnotation extends ExpressiveCodeAnnotation {
@@ -66,15 +66,35 @@ function annotateLine(line: ExpressiveCodeLine) {
 		});
 }
 
+/** Configuration options for the Color Chips plugin. */
+export interface PluginColorChipsOptions {
+	/**
+	 * The language tags to annotate colors in.
+	 *
+	 * Set this to override the built-in CSS dialects (`css`, `scss`, `sass`,
+	 * `less`, and `stylus`) and enable color chips for other languages that
+	 * include color values. The value you provide replaces the defaults, so
+	 * include any built-in dialects you still want to annotate.
+	 *
+	 * ```js
+	 * pluginColorChips({ languages: ['css', 'json'] })
+	 * ```
+	 *
+	 * @default ['css', 'scss', 'sass', 'less', 'stylus']
+	 */
+	languages?: string[];
+}
+
 /**
  * Expressive Code plugin that adds a small preview of each CSS color in your code examples.
  */
-export function pluginColorChips() {
+export function pluginColorChips({ languages = cssDialects }: PluginColorChipsOptions = {}) {
+	const enabledLanguages = new Set(languages);
 	return definePlugin({
 		name: 'ColorChips',
 		hooks: {
 			postprocessAnalyzedCode({ codeBlock }) {
-				if (cssDialects.has(codeBlock.language)) {
+				if (enabledLanguages.has(codeBlock.language)) {
 					codeBlock.getLines().forEach((line) => annotateLine(line));
 				}
 			},


### PR DESCRIPTION
Adds an options object to `pluginColorChips()` with a `languages` array that controls which language tags get color chips. The value replaces the built-in CSS dialects (css, scss, sass, less, stylus), letting users enable color chips for other languages that include color values, e.g. `pluginColorChips({ languages: ['css', 'json'] })`.

Closes #150