### PR TITLE
Avoid matching named colors inside identifiers

### DIFF
--- a/.changeset/tidy-color-boundaries.md
+++ b/.changeset/tidy-color-boundaries.md
@@ -1,0 +1,5 @@
+---
+'expressive-code-color-chips': patch
+---
+
+Avoid rendering named color chips for substrings inside identifiers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
           node-version: 24.18.0
           cache: pnpm
       - run: pnpm i
+      - run: pnpm test
       - run: pnpm build
       - run: pnpm build:docs

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"scripts": {
 		"build": "pnpm -F expressive-code-color-chips build",
 		"build:docs": "pnpm -F @expressive-code-color-chips/docs build",
+		"test": "pnpm -F expressive-code-color-chips test",
 		"ci-version": "changeset version && pnpm install --no-frozen-lockfile",
 		"ci-publish": "pnpm build && changeset publish"
 	}

--- a/packages/expressive-code-color-chips/package.json
+++ b/packages/expressive-code-color-chips/package.json
@@ -29,6 +29,7 @@
 	],
 	"scripts": {
 		"build": "tsdown ./src/index.ts --no-fixed-extension",
+		"test": "tsdown ./src/index.ts --no-fixed-extension && node --test test/*.test.mjs",
 		"watch": "pnpm build --watch src"
 	},
 	"devDependencies": {

--- a/packages/expressive-code-color-chips/src/index.ts
+++ b/packages/expressive-code-color-chips/src/index.ts
@@ -34,6 +34,18 @@ class CssColorAnnotation extends ExpressiveCodeAnnotation {
 /** Match all CSS comments in a line, including trailing unclosed comments or leading comments. */
 const commentRegEx = /(?:^[^*]*\*\/)?\/\*[^*]*(?:\*\/)?/gi;
 
+/** Characters that can continue a CSS identifier. */
+const cssIdentifierCharacterRegEx = /^[-_a-zA-Z0-9\\\u00A0-\uFFFF]$/;
+
+function isStandaloneNamedColor(match: RegExpMatchArray, line: string) {
+	const start = match.index;
+	const end = start + match[0].length;
+	return (
+		!cssIdentifierCharacterRegEx.test(line[start - 1] ?? '') &&
+		!cssIdentifierCharacterRegEx.test(line[end] ?? '')
+	);
+}
+
 /**
  * Process a code block line and annotate any colors found.
  */
@@ -47,7 +59,9 @@ function annotateLine(line: ExpressiveCodeLine) {
 		...line.text.matchAll(colors.programmatic),
 		// Colors expressed with a named keyword, e.g. “blue” or “Canvas”.
 		...[...line.text.matchAll(colors.named)].filter(
-			(match) => !commentPositions.includes(match.index)
+			(match) =>
+				!commentPositions.includes(match.index) &&
+				isStandaloneNamedColor(match, line.text)
 		),
 	]
 		// Sort matches in reverse order by start position in the line (i.e. last match first).

--- a/packages/expressive-code-color-chips/test/index.test.mjs
+++ b/packages/expressive-code-color-chips/test/index.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { ExpressiveCodeEngine } from '@expressive-code/core';
+import { toHtml } from '@expressive-code/core/hast';
+import { pluginColorChips } from '../dist/index.js';
+
+async function render(code) {
+	const engine = new ExpressiveCodeEngine({
+		plugins: [pluginColorChips({ languages: ['metro'] })],
+	});
+	const result = await engine.render({ code, language: 'metro', meta: '' });
+	return toHtml(result.renderedGroupAst);
+}
+
+function countChips(html) {
+	return html.match(/class="ec-css-color-chip"/g)?.length ?? 0;
+}
+
+describe('named colors', () => {
+	test('annotates standalone color keywords', async () => {
+		const html = await render('color: salmon; border-color: darkred;');
+
+		assert.equal(countChips(html), 2);
+		assert.match(html, /--ec-css-color-chip: salmon/);
+		assert.match(html, /--ec-css-color-chip: darkred/);
+	});
+
+	test('does not annotate color keywords inside identifiers', async () => {
+		const html = await render('star_salmon salmon_star darkredValue red-500');
+
+		assert.equal(countChips(html), 0);
+	});
+
+	test('continues to annotate other color syntaxes beside identifiers', async () => {
+		const html = await render(
+			'%%metro line: star_salmon | Aligner: STAR, Quantification: RSEM | #2db572'
+		);
+
+		assert.equal(countChips(html), 1);
+		assert.match(html, /--ec-css-color-chip: #2db572/);
+	});
+});


### PR DESCRIPTION
## Summary

Named CSS colors are currently matched inside longer identifiers. For example, `salmon` in `star_salmon` receives a color chip even though it is part of an identifier.

This change requires named colors to have CSS identifier boundaries. It prevents false positives in values such as `star_salmon`, `darkredValue`, and `red-500`, while standalone colors such as `color: salmon` continue to receive chips. Hex values and other programmatic color syntax are unaffected.

Standalone color words in prose are still treated as valid CSS named colors. Distinguishing those would require language-specific parsing and is outside this generic plugin.

## Verification

- Added rendering tests for standalone colors, embedded color names, and adjacent hex colors.
- Ran the package tests, package build, and documentation build.
- Verified the original example in an Astro and Starlight site with Playwright. Identifier substrings remained plain, while standalone and hex colors retained their chips.
