### PR TITLE
Add an escape marker for individual color chips

### DIFF
--- a/.changeset/tidy-colors-rest.md
+++ b/.changeset/tidy-colors-rest.md
@@ -1,0 +1,5 @@
+---
+'expressive-code-color-chips': minor
+---
+
+Adds an opt-in `escapeMarker` option for suppressing individual color chips without displaying the marker.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
           node-version: 24.18.0
           cache: pnpm
       - run: pnpm i
+      - run: pnpm test
       - run: pnpm build
       - run: pnpm build:docs

--- a/docs/ec.config.mjs
+++ b/docs/ec.config.mjs
@@ -2,7 +2,7 @@ import { defineEcConfig } from '@astrojs/starlight/expressive-code';
 import { pluginColorChips } from 'expressive-code-color-chips';
 
 export default defineEcConfig({
-	plugins: [pluginColorChips()],
+	plugins: [pluginColorChips({ escapeMarker: '\\' })],
 	styleOverrides: {
 		colorChips: {
 			// borderRadius: 0,

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -19,6 +19,23 @@ By default, the plugin annotates colors in `css`, `scss`, `sass`, `less`, and `s
 
 The value you provide replaces the defaults, so include any of the built-in CSS dialects you still want to annotate.
 
+## Suppressing individual chips
+
+Set `escapeMarker` to enable an opt-in marker that suppresses individual color chips. For example, you can use a backslash:
+
+```js
+{
+	plugins: [pluginColorChips({ escapeMarker: '\\' })],
+},
+```
+
+With this configuration, writing `\#2db572` or `\salmon` in a code block renders and copies as `#2db572` or `salmon`, without a color chip. The marker is only removed when it immediately precedes a recognized color. Backslashes elsewhere in the code are unchanged.
+
+```css
+.with-preview { color: #0570b0; }
+.without-preview { color: \#2db572; }
+```
+
 ## Styling
 
 You can provide custom styles in your Expressive Code config using the `styleOverrides.colorChips` object.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"scripts": {
 		"build": "pnpm -F expressive-code-color-chips build",
 		"build:docs": "pnpm -F @expressive-code-color-chips/docs build",
+		"test": "pnpm -F expressive-code-color-chips test",
 		"ci-version": "changeset version && pnpm install --no-frozen-lockfile",
 		"ci-publish": "pnpm build && changeset publish"
 	}

--- a/packages/expressive-code-color-chips/package.json
+++ b/packages/expressive-code-color-chips/package.json
@@ -29,6 +29,7 @@
 	],
 	"scripts": {
 		"build": "tsdown ./src/index.ts --no-fixed-extension",
+		"test": "tsdown ./src/index.ts --no-fixed-extension && node --test test/*.test.mjs",
 		"watch": "pnpm build --watch src"
 	},
 	"devDependencies": {

--- a/packages/expressive-code-color-chips/src/index.ts
+++ b/packages/expressive-code-color-chips/src/index.ts
@@ -34,22 +34,26 @@ class CssColorAnnotation extends ExpressiveCodeAnnotation {
 /** Match all CSS comments in a line, including trailing unclosed comments or leading comments. */
 const commentRegEx = /(?:^[^*]*\*\/)?\/\*[^*]*(?:\*\/)?/gi;
 
-/**
- * Process a code block line and annotate any colors found.
- */
-function annotateLine(line: ExpressiveCodeLine) {
+/** Return every color that the plugin would annotate in a line. */
+function findColors(line: ExpressiveCodeLine) {
 	/** An array of character positions that are inside comments. */
 	const commentPositions = [...line.text.matchAll(commentRegEx)]
 		// Convert each match to an array of indexes for characters in that range.
 		.flatMap((match) => Array.from(match[0]).map((_, i) => match.index + i));
-	[
+	return [
 		// Colors expressed with explicit color syntax.
 		...line.text.matchAll(colors.programmatic),
 		// Colors expressed with a named keyword, e.g. “blue” or “Canvas”.
 		...[...line.text.matchAll(colors.named)].filter(
 			(match) => !commentPositions.includes(match.index)
 		),
-	]
+	];
+}
+
+/** Process a code block line and annotate colors outside the excluded positions. */
+function annotateLineExcept(line: ExpressiveCodeLine, excludedPositions: Set<number>) {
+	findColors(line)
+		.filter((match) => !excludedPositions.has(match.index))
 		// Sort matches in reverse order by start position in the line (i.e. last match first).
 		.sort((a, b) => b.index - a.index)
 		// Annotate each match.
@@ -64,6 +68,23 @@ function annotateLine(line: ExpressiveCodeLine) {
 				})
 			);
 		});
+}
+
+/** Remove escape markers before colors and return their adjusted start positions. */
+function removeColorEscapes(line: ExpressiveCodeLine, escapeMarker: string) {
+	const escapedMatches = findColors(line)
+		.filter(
+			(match) =>
+				line.text.slice(match.index - escapeMarker.length, match.index) === escapeMarker
+		)
+		.sort((a, b) => a.index - b.index);
+	const excludedPositions = new Set(
+		escapedMatches.map((match, index) => match.index - escapeMarker.length * (index + 1))
+	);
+	escapedMatches.reverse().forEach((match) => {
+		line.editText(match.index - escapeMarker.length, match.index, '');
+	});
+	return excludedPositions;
 }
 
 /** Configuration options for the Color Chips plugin. */
@@ -83,19 +104,52 @@ export interface PluginColorChipsOptions {
 	 * @default ['css', 'scss', 'sass', 'less', 'stylus']
 	 */
 	languages?: string[];
+	/**
+	 * An optional marker for suppressing individual color chips.
+	 *
+	 * The marker is removed from rendered and copied code when it immediately
+	 * precedes a recognized color. The color itself remains visible but is not
+	 * annotated.
+	 *
+	 * ```js
+	 * pluginColorChips({ escapeMarker: '\\' })
+	 * ```
+	 *
+	 * With this configuration, `\#2db572` renders as `#2db572` without a chip.
+	 *
+	 * @default undefined
+	 */
+	escapeMarker?: string;
 }
 
 /**
  * Expressive Code plugin that adds a small preview of each CSS color in your code examples.
  */
-export function pluginColorChips({ languages = cssDialects }: PluginColorChipsOptions = {}) {
+export function pluginColorChips({
+	languages = cssDialects,
+	escapeMarker,
+}: PluginColorChipsOptions = {}) {
+	if (escapeMarker === '') {
+		throw new Error('The Color Chips escape marker cannot be empty.');
+	}
 	const enabledLanguages = new Set(languages);
+	const excludedPositions = new WeakMap<ExpressiveCodeLine, Set<number>>();
 	return definePlugin({
 		name: 'ColorChips',
 		hooks: {
+			preprocessCode({ codeBlock }) {
+				if (escapeMarker && enabledLanguages.has(codeBlock.language)) {
+					codeBlock.getLines().forEach((line) => {
+						const positions = removeColorEscapes(line, escapeMarker);
+						if (positions.size > 0) excludedPositions.set(line, positions);
+					});
+				}
+			},
 			postprocessAnalyzedCode({ codeBlock }) {
 				if (enabledLanguages.has(codeBlock.language)) {
-					codeBlock.getLines().forEach((line) => annotateLine(line));
+					codeBlock
+						.getLines()
+						.forEach((line) => annotateLineExcept(line, excludedPositions.get(line) ?? new Set()));
 				}
 			},
 		},

--- a/packages/expressive-code-color-chips/test/index.test.mjs
+++ b/packages/expressive-code-color-chips/test/index.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { ExpressiveCodeEngine } from '@expressive-code/core';
+import { toHtml, toText } from '@expressive-code/core/hast';
+import { pluginColorChips } from '../dist/index.js';
+
+async function render(code, options = {}) {
+	const engine = new ExpressiveCodeEngine({
+		plugins: [pluginColorChips({ languages: ['text'], ...options })],
+	});
+	return engine.render({ code, language: 'text', meta: '' });
+}
+
+function countChips(html) {
+	return html.match(/class="ec-css-color-chip"/g)?.length ?? 0;
+}
+
+describe('escape marker', () => {
+	test('suppresses an individual hexadecimal color without rendering the marker', async () => {
+		const result = await render('visible #0570b0 hidden \\#2db572', { escapeMarker: '\\' });
+		const html = toHtml(result.renderedGroupAst);
+
+		assert.equal(countChips(html), 1);
+		assert.match(html, /--ec-css-color-chip: #0570b0/);
+		assert.doesNotMatch(html, /--ec-css-color-chip: #2db572/);
+		assert.equal(toText(result.renderedGroupAst), 'visible #0570b0 hidden #2db572');
+	});
+
+	test('suppresses named colors and multiple colors on one line', async () => {
+		const result = await render('\\salmon \\#2db572 blue', { escapeMarker: '\\' });
+		const html = toHtml(result.renderedGroupAst);
+
+		assert.equal(countChips(html), 1);
+		assert.match(html, /--ec-css-color-chip: blue/);
+		assert.equal(toText(result.renderedGroupAst), 'salmon #2db572 blue');
+	});
+
+	test('preserves markers that do not immediately precede a color', async () => {
+		const result = await render('path\\segment \\not-a-color #2db572', { escapeMarker: '\\' });
+		const html = toHtml(result.renderedGroupAst);
+
+		assert.equal(countChips(html), 1);
+		assert.equal(toText(result.renderedGroupAst), 'path\\segment \\not-a-color #2db572');
+	});
+
+	test('supports custom multi-character markers', async () => {
+		const result = await render('plain #0570b0 hidden !#!#2db572', {
+			escapeMarker: '!#!',
+		});
+		const html = toHtml(result.renderedGroupAst);
+
+		assert.equal(countChips(html), 1);
+		assert.equal(toText(result.renderedGroupAst), 'plain #0570b0 hidden #2db572');
+	});
+
+	test('only removes markers in enabled languages', async () => {
+		const engine = new ExpressiveCodeEngine({
+			plugins: [pluginColorChips({ languages: ['css'], escapeMarker: '\\' })],
+		});
+		const result = await engine.render({ code: '\\#2db572', language: 'text', meta: '' });
+
+		assert.equal(countChips(toHtml(result.renderedGroupAst)), 0);
+		assert.equal(toText(result.renderedGroupAst), '\\#2db572');
+	});
+
+	test('does not change behavior unless an escape marker is configured', async () => {
+		const result = await render('\\#2db572');
+
+		assert.equal(countChips(toHtml(result.renderedGroupAst)), 1);
+		assert.equal(toText(result.renderedGroupAst), '\\#2db572');
+	});
+
+	test('rejects an empty escape marker', () => {
+		assert.throws(() => pluginColorChips({ escapeMarker: '' }), /cannot be empty/);
+	});
+});


### PR DESCRIPTION
## Summary

This adds an opt-in `escapeMarker` option for suppressing a single color chip without changing the displayed or copied code.

For example, with `pluginColorChips({ escapeMarker: '\\' })`:

- `#0570b0` renders with a color chip.
- `\#2db572` renders and copies as `#2db572`, without a chip.
- Backslashes that do not immediately precede a recognized color remain unchanged.

The option is disabled by default, so existing configurations are unaffected. The marker is configurable and may contain more than one character.

## Verification

- Added tests for hex and named colors, multiple escapes, custom markers, disabled languages, unrelated markers, copied text, default behavior, and invalid empty markers.
- Ran the package tests, package build, and documentation build.
- Verified the live documentation example in a production Astro preview with Playwright. The escaped color had no chip or visible marker, while the neighboring unescaped color retained its chip.
